### PR TITLE
Update code to resolve issue-15

### DIFF
--- a/R/verify_bins.R
+++ b/R/verify_bins.R
@@ -28,6 +28,7 @@ verify_bins <- function(entry, challenge = "ilinet") {
   
   errors <- character()
   errors_x <- character()
+  has_error <- FALSE
   
   for(i in seq_along(entry_targets)) {
     entry_bins <- unique(entry$bin[entry$target == entry_targets[i]])
@@ -46,11 +47,20 @@ verify_bins <- function(entry, challenge = "ilinet") {
                                      extra_bins, "\n"))
   }
   
-  if (length(errors) > 0)
-    stop(errors)
+  if (length(errors) > 0) {
+    warning(errors)
+    has_error <- TRUE
+  }
   
-  if (length(errors_x) > 0)
-    stop(errors_x)
+  if (length(errors_x) > 0) {
+    warning(errors_x)
+    has_error <- TRUE
+  }
   
-  return(invisible(TRUE))
+  if (has_error) {
+    return(invisible(FALSE))
+  } else {
+    return(invisible(TRUE))
+  }
+  
 }

--- a/R/verify_entry.R
+++ b/R/verify_entry.R
@@ -59,12 +59,14 @@ verify_entry <- function(entry, challenge = "ilinet") {
   cdcForecastUtils::verify_colnames(entry)
   
   # Verify column contents
-  cdcForecastUtils::verify_locations(entry, challenge)
-  cdcForecastUtils::verify_targets(entry, challenge)
-  cdcForecastUtils::verify_types(entry, challenge)
-  cdcForecastUtils::verify_bins(entry, challenge)
-  cdcForecastUtils::verify_probabilities(entry)
-  cdcForecastUtils::verify_point(entry)
+  verified_locations <- cdcForecastUtils::verify_locations(entry, challenge)
+  verified_targets <- cdcForecastUtils::verify_targets(entry, challenge)
+  verified_types <- cdcForecastUtils::verify_types(entry, challenge)
+  verified_bins <- cdcForecastUtils::verify_bins(entry, challenge)
+  verified_probabilities <- cdcForecastUtils::verify_probabilities(entry)
+  verified_point <- cdcForecastUtils::verify_point(entry)
   
-  return(invisible(TRUE))
+  if (verified_locations && verified_targets && verified_types && verified_bins && verified_probabilities && verified_point)
+    return(invisible(TRUE))
+  stop("Entry did not pass all verification test")
 }

--- a/R/verify_locations.R
+++ b/R/verify_locations.R
@@ -38,17 +38,25 @@ verify_locations <- function(entry, challenge = "ilinet") {
   # Determine extra locations and non-required missing locations
   extra_locations   <- setdiff(entry_locations, valid_locations)
   possible_locations <- setdiff(valid_locations, entry_locations)
+  has_error <- FALSE
+  
   if (length(intersect(entry_locations, valid_locations))==0){
-    stop("Missing all valid locations. Wrong challenge?: ", paste(extra_locations,sep=", "))
+    warning("Missing all valid locations. Wrong challenge?: ", paste(extra_locations,collapse=", "))
+    has_error <- TRUE
   }
   if (length(extra_locations)>0){ 
-    stop("These extra locations are ignored. Please check for possible spelling errors: ", 
-            paste(extra_locations,sep=""))
+    warning("These extra locations are ignored. Please check for possible spelling errors: ", 
+            paste(extra_locations,collapse=", "))
+    has_error <- TRUE
   }
   if (length(possible_locations)>0)
     # message("Consider forecasting for these locations: ", paste(possible_locations))
     message("Please check if this is intended - these locations have no forecast: ", 
             paste(possible_locations, collapse = ", "))
   
-  return(invisible(TRUE))
+  if (has_error) {
+    return(invisible(FALSE))
+  } else {
+    return(invisible(TRUE))
+  }
 }

--- a/R/verify_point.R
+++ b/R/verify_point.R
@@ -27,32 +27,36 @@ verify_point <- function(entry) {
     dplyr::mutate(weekrange=ifelse((!(is.na(value)) &  grepl("2020-ew[0-9]{2}", value)),
                                as.numeric(substr(value,8,10)),NA),
                   check_range=ifelse((!(is.na(weekrange)) ),(weekrange>35 |weekrange<10),FALSE))
+  has_error <- FALSE
   
   # Report warning for missing point predictions
   if (any(point$miss)) {
     tmp <- point %>%
       dplyr::filter(miss)
     
-    stop(paste0("WARNING: Missing point predictions detected in ",
+    warning(paste0("WARNING: Missing point predictions detected in ",
                    paste(tmp$location, tmp$target), ". \n",
                    "Please take a look at cdcForecastUtils::generate_point_forecasts().\n"))
+    has_error <- TRUE
   }
   if (any(point_char$miss)) {
     tmp <- point_char %>%
       dplyr::filter(miss)
     
-    stop(paste0("ERROR: Missing point predictions detected in ",
+    warning(paste0("ERROR: Missing point predictions detected in ",
                 paste(tmp$location, tmp$target), ". \n",
                 "Please take a look at cdcForecastUtils::generate_point_forecasts().\n"))
+    has_error <- TRUE
   }
   # Report error for negative point predictions
   if (any(point$negative)) {
     tmp <- point %>%
       dplyr::filter(negative)
     
-    stop(paste0("ERROR: Negative point predictions detected in ",
+    warning(paste0("ERROR: Negative point predictions detected in ",
                 paste(tmp$location, tmp$target), ". \n",
                 "Please take a look at cdcForecastUtils::generate_point_forecasts().\n"))
+    has_error <- TRUE
   }
 
   # Report error for out of range week
@@ -60,18 +64,25 @@ verify_point <- function(entry) {
     tmp <- point_char %>%
       dplyr::filter(check_range)
     
-    stop(paste0("ERROR: Out-of-range point predictions for week targets detected in ",
+    warning(paste0("ERROR: Out-of-range point predictions for week targets detected in ",
                 paste(tmp$location, tmp$target), ". \n",
                 "Please take a look at cdcForecastUtils::generate_point_forecasts().\n"))
+    has_error <- TRUE
   }
   # Report week format error
   if (any(point_char$weekformat)) {
     tmp <- point_char %>%
       dplyr::filter(weekformat)
     
-    stop(paste0("ERROR: Empty, incorrect format or season for week target's point predictions detected in ",
+    warning(paste0("ERROR: Empty, incorrect format or season for week target's point predictions detected in ",
                 paste(tmp$location, tmp$target), ". \n",
                 "Please take a look at cdcForecastUtils::generate_point_forecasts().\n"))
+    has_error <- TRUE
   }
-  return(invisible(TRUE))
+  
+  if (has_error) {
+    return(invisible(FALSE))
+  } else {
+    return(invisible(TRUE))
+  }
 }

--- a/R/verify_probabilities.R
+++ b/R/verify_probabilities.R
@@ -32,6 +32,7 @@ verify_probabilities <- function(entry) {
       negative = any(!is.na(value) & value < 0))
   
   errors <- character()
+  has_error <- FALSE
   # Report message for missing probabilities
   # fix for intentional missing for targets not forecasted
   if (any(probabilities$miss)) {
@@ -78,8 +79,13 @@ verify_probabilities <- function(entry) {
   }
   #Output probability related errors
   if (length(errors) != 0) {
-    stop(errors)
+    warning(errors)
+    has_error <- TRUE
   }
 
-  return(invisible(TRUE))
+  if (has_error) {
+    return(invisible(FALSE))
+  } else {
+    return(invisible(TRUE))
+  }
 }

--- a/R/verify_targets.R
+++ b/R/verify_targets.R
@@ -31,13 +31,19 @@ verify_targets <- function(entry, challenge = "ilinet") {
   
   missing_targets <- setdiff(valid_targets, entry_targets)
   extra_targets   <- setdiff(entry_targets, valid_targets)
-  
+  has_error <- FALSE
   if (length(missing_targets)>0)
     # message not warning or stop because it might be intentional
     message("Please check if this is intended - Missing these targets: ", paste(missing_targets, collapse=", "))
   
-  if (length(extra_targets)>0)
-    stop("These extra targets are not valid. Please check capitalization or spelling: ", paste(extra_targets, collapse=", "))
+  if (length(extra_targets)>0) {
+    warning("These extra targets are not valid. Please check capitalization or spelling: ", paste(extra_targets, collapse=", "))
+    has_error <- TRUE
+  }
   
-  return(invisible(TRUE))
+  if (has_error) {
+    return(invisible(FALSE))
+  } else {
+    return(invisible(TRUE))
+  }
 }

--- a/R/verify_types.R
+++ b/R/verify_types.R
@@ -30,12 +30,21 @@ verify_types <- function(entry, challenge = "ilinet") {
   
   missing_types <- setdiff(valid_types, entry_types)
   extra_types   <- setdiff(entry_types, valid_types)
+  has_error <- FALSE
   
-  if (length(missing_types)>0)
-    stop("Missing these types: ", paste(missing_types, collapse=", "))
+  if (length(missing_types)>0) {
+    warning("Missing these types: ", paste(missing_types, collapse=", "))
+    has_error <- TRUE
+  }
   
-  if (length(extra_types)>0 && extra_types != "point")
-    stop("These extra types are not valid: ", paste(extra_types, collapse=", "))
+  if (length(extra_types)>0 && extra_types != "point") {
+    warning("These extra types are not valid: ", paste(extra_types, collapse=", "))
+    has_error <- TRUE
+  }
   
-  return(invisible(TRUE))
+  if (has_error) {
+    return(invisible(FALSE))
+  } else {
+    return(invisible(TRUE))
+  }
 }

--- a/tests/testthat/test-get_time_left_in_season.R
+++ b/tests/testthat/test-get_time_left_in_season.R
@@ -16,7 +16,7 @@ test_that("Missing bins report errors.", {
   
   for (i in seq_along(valid_bins)) {
     tmp_entry <- full_entry_new[full_entry_new$bin != valid_bins[i], ]
-    expect_error(verify_bins(tmp_entry))
+    expect_warning(verify_bins(tmp_entry))
   }
 })
 

--- a/tests/testthat/test-verify_bins.R
+++ b/tests/testthat/test-verify_bins.R
@@ -16,7 +16,7 @@ test_that("Missing bins report errors.", {
   
   for (i in seq_along(valid_bins)) {
     tmp_entry <- full_entry_new[full_entry_new$bin != valid_bins[i], ]
-    expect_error(verify_bins(tmp_entry))
+    expect_warning(verify_bins(tmp_entry))
   }
 })
 

--- a/tests/testthat/test-verify_entry.R
+++ b/tests/testthat/test-verify_entry.R
@@ -41,7 +41,7 @@ test_that("Return error when probabilities are missing", {
                         invalid_entry$target == rand_target &
                         invalid_entry$type == "bin"] <- NA
   
-  expect_error(verify_probabilities(invalid_entry))
+  expect_warning(verify_probabilities(invalid_entry))
   expect_error(verify_entry(invalid_entry))
   
 })
@@ -56,7 +56,7 @@ test_that("Return error when probabilities are negative", {
                         invalid_entry$target == rand_target &
                         invalid_entry$type == "bin"] <- -0.5
   
-  expect_error(verify_probabilities(invalid_entry))
+  expect_warning(verify_probabilities(invalid_entry))
   expect_error(verify_entry(invalid_entry))
   
 })
@@ -71,7 +71,7 @@ test_that("Return error when probabilities sum to less than 0.9", {
                         invalid_entry$target == rand_target &
                         invalid_entry$type == "bin"] <- 0.01
   
-  expect_error(verify_probabilities(invalid_entry))
+  expect_warning(verify_probabilities(invalid_entry))
   expect_error(verify_entry(invalid_entry))
   
   
@@ -87,7 +87,7 @@ test_that("Return error when probabilities sum to more than 1.1", {
                         invalid_entry$target == rand_target &
                         invalid_entry$type == "bin"] <- 0.1
   
-  expect_error(verify_probabilities(invalid_entry))
+  expect_warning(verify_probabilities(invalid_entry))
   expect_error(verify_entry(invalid_entry))
   
 })
@@ -101,7 +101,7 @@ test_that("Return warning when point forecast is missing", {
                         invalid_entry$target == rand_target &
                         invalid_entry$type == "point"] <- NA
   
-  expect_error(verify_point(invalid_entry))
+  expect_warning(verify_point(invalid_entry))
   expect_error(verify_entry(invalid_entry))
   
 })
@@ -114,7 +114,7 @@ test_that("Return error when point forecast is negative", {
   invalid_entry$value[invalid_entry$location == rand_location &
                         invalid_entry$target == rand_target &
                         invalid_entry$type == "point"] <- -1
-  expect_error(verify_point(invalid_entry))
+  expect_warning(verify_point(invalid_entry))
   expect_error(verify_entry(invalid_entry))
   
 })

--- a/tests/testthat/test-verify_point.R
+++ b/tests/testthat/test-verify_point.R
@@ -14,7 +14,7 @@ test_that("Missing point predictions return warning", {
                        invalid_full$target == rand_target &
                        invalid_full$type == "point"] <- NA
   
-  expect_error(verify_point(invalid_full))
+  expect_warning(verify_point(invalid_full))
 
 })
 
@@ -27,7 +27,7 @@ test_that("Negative point prediction return error", {
                        invalid_full$target == rand_target &
                        invalid_full$type == "point"] <- -1
   
-  expect_error(verify_point(invalid_full))
+  expect_warning(verify_point(invalid_full))
   
 })
 
@@ -42,7 +42,7 @@ test_that("Out of range point prediction for week targets return error", {
                        invalid_full$target == rand_target &
                        invalid_full$type == "point"] <- "2020-EW43"
   
-  expect_error(verify_point(invalid_full))
+  expect_warning(verify_point(invalid_full))
   
 })
 
@@ -57,6 +57,6 @@ test_that("Incorrect point prediction format for week targets return error", {
                        invalid_full$target == rand_target &
                        invalid_full$type == "point"] <- "2019-EW43"
   
-  expect_error(verify_point(invalid_full))
+  expect_warning(verify_point(invalid_full))
   
 })

--- a/tests/testthat/test-verify_probabilities.R
+++ b/tests/testthat/test-verify_probabilities.R
@@ -19,8 +19,8 @@ test_that("Missing probabilities throw errors", {
                        invalid_full$target == rand_target &
                        invalid_full$type == "bin"] <- NA
   
-  expect_error(verify_probabilities(invalid_min))
-  expect_error(verify_probabilities(invalid_full))
+  expect_warning(verify_probabilities(invalid_min))
+  expect_warning(verify_probabilities(invalid_full))
   
 })
 
@@ -34,7 +34,7 @@ test_that("Negative probabilities throw errors", {
                        invalid_full$type == "bin"] <- -0.1
   
   expect_error(verify_probabilities(invalid_min))
-  expect_error(verify_probabilities(invalid_full))
+  expect_warning(verify_probabilities(invalid_full))
   
 })
 
@@ -48,7 +48,7 @@ test_that("Probabilities summing to < 0.9 throw errors", {
                        invalid_full$type == "bin"] <- 0.01
   
   expect_error(verify_probabilities(invalid_min))
-  expect_error(verify_probabilities(invalid_full))
+  expect_warning(verify_probabilities(invalid_full))
   
 })
 
@@ -62,7 +62,7 @@ test_that("Probabilities summing to > 1.1 throw errors", {
                        invalid_full$type == "bin"] <- 0.1
   
   expect_error(verify_probabilities(invalid_min))
-  expect_error(verify_probabilities(invalid_full))
+  expect_warning(verify_probabilities(invalid_full))
   
 })
 
@@ -76,6 +76,6 @@ test_that("Binary probabilities higher than 1 throw errors", {
                        invalid_full$type == "bin"] <- 1.1
   
   expect_error(verify_probabilities(invalid_min))
-  expect_error(verify_probabilities(invalid_full))
+  expect_warning(verify_probabilities(invalid_full))
   
 })

--- a/tests/testthat/test-verify_types.R
+++ b/tests/testthat/test-verify_types.R
@@ -10,7 +10,7 @@ test_that("Missing types report errors.", {
   
   for (i in seq_along(valid_types)) {
     tmp_entry <- full_entry_new[full_entry_new$type != valid_types[i],]
-    expect_error(verify_types(tmp_entry))
+    expect_warning(verify_types(tmp_entry))
   }
 })
 


### PR DESCRIPTION
Updating codes to resolve this issue: https://github.com/reichlab/cdcForecastUtils/issues/15

Problem: execution is halt when stop() is called in one these functions. We would like to change this so that all cdcForecastUtils::verify_(locations, targets, types, bins, probabilities, point) get to run, any error that appears will be notify to the users, and only call stop() after all these functions are run.

Approach: change any stop() to warning() in these functions cdcForecastUtils::verify_(locations, targets, types, bins, probabilities, point) and make these function return FALSE. After all these functions are run, if any of them return FALSE, verify_entry() will be the function that call stop(). All related tests are updated accordingly (expect_error() -> expect_warning() in appropriate places)

Before merging, this branch needs Nutcha and Nick comment!!!
